### PR TITLE
entrypoint.sh 处理容器时间和数据库时间不一致;dbca.rsp  java_jit_enabled=false (否则在76…

### DIFF
--- a/assets/dbca.rsp
+++ b/assets/dbca.rsp
@@ -608,7 +608,7 @@ CHARACTERSET="AL32UTF8"
 # Default value : None
 # Mandatory     : NO
 #-----------------------------------------------------------------------------
-INITPARAMS="memory_target=0,sga_target=500,pga_aggregate_target=100"
+INITPARAMS="memory_target=0,sga_target=500,pga_aggregate_target=100,java_jit_enabled=false"
 
 #-----------------------------------------------------------------------------
 # Name          : SAMPLESCHEMA

--- a/assets/entrypoint.sh
+++ b/assets/entrypoint.sh
@@ -8,5 +8,7 @@ if [ ! -d "/u01/app/oracle/product/11.2.0/dbhome_1" ]; then
 	/assets/install.sh
 fi
 
+cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
+
 su oracle -c "/assets/entrypoint_oracle.sh"
 


### PR DESCRIPTION
…%会挂起);entrypoint_oracle.sh (在start_db()中:替换listener中的主机名;启动容器需要执行sql时,可挂载/oracle-initdb.d,就会自动执行)